### PR TITLE
Expose `plugins` resource

### DIFF
--- a/src/Resources/Plugins.php
+++ b/src/Resources/Plugins.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace RickWest\WordPress\Resources;
+
+class Plugins extends Resource
+{
+
+}

--- a/src/WordPress.php
+++ b/src/WordPress.php
@@ -8,6 +8,7 @@ use RickWest\WordPress\Resources\Media;
 use RickWest\WordPress\Resources\Pages;
 use RickWest\WordPress\Resources\Posts;
 use RickWest\WordPress\Resources\Users;
+use RickWest\WordPress\Resources\Plugins;
 
 /**
  * @method Comments comments()
@@ -16,6 +17,7 @@ use RickWest\WordPress\Resources\Users;
  * @method Pages pages()
  * @method Posts posts()
  * @method Users users()
+ * @method Plugins plugins()
  */
 class WordPress extends BaseWordPress
 {
@@ -26,5 +28,6 @@ class WordPress extends BaseWordPress
         'pages' => Pages::class,
         'posts' => Posts::class,
         'users' => Users::class,
+        'plugins' => Plugins::class,
     ];
 }

--- a/tests/WordPressTest.php
+++ b/tests/WordPressTest.php
@@ -14,6 +14,7 @@ use RickWest\WordPress\Resources\Pages;
 use RickWest\WordPress\Resources\Posts;
 use RickWest\WordPress\Resources\Resource;
 use RickWest\WordPress\Resources\Users;
+use RickWest\WordPress\Resources\Plugins;
 use RickWest\WordPress\WordPress;
 
 class WordPressTest extends TestCase
@@ -138,6 +139,7 @@ class WordPressTest extends TestCase
             ['pages', Pages::class, ],
             ['posts', Posts::class, ],
             ['users', Users::class, ],
+            ['plugins', Plugins::class, ],
         ];
     }
 }


### PR DESCRIPTION
This PR adds the [`plugins` resource.](https://developer.wordpress.org/rest-api/reference/plugins/)

Unsure if we need to enhance the resource with a `useStatus`trait... What do you think?

Thanks a lot for sharing this great package!