### PR TITLE
Allow custom Http client options

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ WORDPRESS_URL=https://example.com
 
 ## Usage
 
-This package binds a singleton to the Laravel service container, so you can easily resolve the WordPress client directly from the container, or via dependency injection. 
+This package binds a singleton to the Laravel service container, so you can easily resolve the WordPress client directly from the container, or via dependency injection.
 Alternatively, the package also exposes both a Facade and a helper function should you prefer a shorter more expressive option.
 
-Currently, the package has support for the following WordPress resources: *categories, comments, media, pages, posts, users*. 
+Currently, the package has support for the following WordPress resources: *categories, comments, media, pages, posts, users*.
 Adding support for further resources is really easy, but these are the only ones that I need for now! For a list of all available resources please see https://developer.wordpress.org/rest-api/reference. I'm happy to accept PR's for any additions.
 
 ```php
@@ -80,7 +80,7 @@ Adding support for further resources is really easy, but these are the only ones
 app(WordPress::class)->posts();
 
 // Resolve via Facade and access the Posts API
-WordPress::posts(); 
+WordPress::posts();
 
 // Resolve service via helper and access the Posts API
 wordpress()->posts();
@@ -106,7 +106,7 @@ Call the `find` method on a resource class in order to get a single resource by 
 ```php
 WordPress::posts()->find(1);
 
-// All WordPress resources share a handful of global parameters. https://developer.wordpress.org/rest-api/using-the-rest-api/global-parameters/ 
+// All WordPress resources share a handful of global parameters. https://developer.wordpress.org/rest-api/using-the-rest-api/global-parameters/
 // You can use the relevant fluent builder methods to add these to your query
 WordPress::posts()->embed()->fields('title')->find(1);
 
@@ -117,7 +117,7 @@ WordPress::posts()->find(1, ['password' => 'pa55w0rd']);
 ### Retrieve a collection of resources
 
 Call the `get` method on a resource to retrieve a collection of resources. The response you receive can be controlled and filtered using various parameters, https://developer.wordpress.org/rest-api/reference/.
-This package provides some fluent builder methods in order to easily and expressively build your desired query. Collection responses are then nicely formatted and include useful pagination information. 
+This package provides some fluent builder methods in order to easily and expressively build your desired query. Collection responses are then nicely formatted and include useful pagination information.
 
 ```php
 WordPress::posts()->get();
@@ -135,24 +135,24 @@ WordPress::posts()
     ->exlclude(int|array $ids) // Ensure result set excludes specific IDs
     ->inlude(int|array $ids) // Limit result set to specific IDs
     ->orderBy(string $field, string $direction) // Sort collection by object attribute, either ascending or descending
-    
-    // Resources with authors  
+
+    // Resources with authors
     ->author() // Limit result set to resources assigned to specific authors
     ->authorExclude() // Ensure result set excludes resources assigned to specific authors
-    
+
     // Resources with dates
     ->after(Carbon $after) // Limit response to resources published after a given ISO8601 compliant date
     ->before(Carbon $before) // Limit response to resources published before a given ISO8601 compliant date
     ->latest() // Order by date, descending
     ->olders() // Order by date, ascending
-    
+
     // Resources with slugs
     ->slug(string $slug)
-    
+
     // When a utility doesn't exist for the parameter
     ->parameter(string $key, mixed $value) // Add a custom parameter to the query
-    
-    // Send it!        
+
+    // Send it!
     ->get();
 
 // Conditionally adding parameters
@@ -175,6 +175,22 @@ WordPress::posts()->send('POST', 1, [
     'json' => ['title' => 'My New Title'],
 ]);
 
+```
+
+### HTTP Client options
+
+Once you have a resource you can set Http client options on it before you make the request:
+
+```php
+// Using the Facade
+WordPress::posts()->withOptions([
+    'verify' => false,
+])->get();
+
+// Using the helper
+wordpress()->posts()->withOptions([
+    'verify' => false,
+])->get();
 ```
 
 ## Testing

--- a/src/Resources/Resource.php
+++ b/src/Resources/Resource.php
@@ -12,6 +12,8 @@ abstract class Resource
 
     protected Query $query;
 
+    protected array $httpOptions = [];
+
     protected string $wrap = 'data';
 
     public function __construct(Client $client)
@@ -30,6 +32,7 @@ abstract class Resource
      */
     public function send(string $method, int $id = null, array $options = []): Response
     {
+        $options = array_merge($options, $this->httpOptions);
         return $this->client->send($method, $this->endpoint().($id ? '/'.$id : ''), $options);
     }
 
@@ -242,6 +245,19 @@ abstract class Resource
         return Str::lower(
             (new \ReflectionClass($this))->getShortName()
         );
+    }
+
+    /**
+     * Set HTTP options for the request.
+     *
+     * @param  array $options
+     * @return $this
+     */
+    public function withOptions(array $options)
+    {
+        $this->httpOptions = $options;
+
+        return $this;
     }
 
     /**

--- a/tests/ResourceTest.php
+++ b/tests/ResourceTest.php
@@ -327,6 +327,19 @@ class ResourceTest extends TestCase
         });
     }
 
+    public function testWithOptions(): void
+    {
+        $this->resource->withOptions(['connect_timeout' => 30, 'verify' => false])->get();
+
+        // There does not seem to be a way to test that a request was
+        // sent with a specific option.
+        // TODO: Find a way to test withOptions()
+
+        // Http::assertSent(function (Request $request) {
+        //     return ??;
+        // });
+    }
+
     public function testGetBuildsCorrectQuery(): void
     {
         $this->resource->latest()


### PR DESCRIPTION
Thanks for the awesome package!

I was using this locally and was getting curl errors:

`cURL error   60: SSL certificate problem: unable to get local issuer certificate`

After realising that I couldn't modify the `verify` option with a [globalRequestMiddleware](https://laravel.com/docs/10.x/http-client#global-middleware) I decided to add a `withOptions` method to enable it.

I've updated the README accordingly.

## Testing

I spent several hours (I know!) trying to find a way to test this, but with how I'm setting the options there does not seem to be a way that I could find. I source-dived, and xDebugged, but the option seems to be set on the curl instance and with the `Fake` I don't think we even get to that depth in the test.

I tried to create a mock, but this felt like we were just testing that the new method does what the new method does.

Happy to take your advice here.

Thanks.